### PR TITLE
Refactor/add insurance policy

### DIFF
--- a/src/main/java/br/com/solutis/locadora/controller/rent/InsurancePolicyController.java
+++ b/src/main/java/br/com/solutis/locadora/controller/rent/InsurancePolicyController.java
@@ -1,12 +1,91 @@
 package br.com.solutis.locadora.controller.rent;
 
+import br.com.solutis.locadora.exception.rent.InsurancePolicyException;
+import br.com.solutis.locadora.exception.rent.InsurancePolicyNotFoundException;
+import br.com.solutis.locadora.model.dto.rent.InsurancePolicyDto;
+import br.com.solutis.locadora.response.ErrorResponse;
+import br.com.solutis.locadora.service.rent.InsurancePolicyService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
 
 @Tag(name = "InsurancePolicyController")
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/insurances")
+@CrossOrigin
 public class InsurancePolicyController {
+    private final InsurancePolicyService insurancePolicyService;
 
+    @Operation(
+            summary = "Find by id",
+            description = "Returns the information of a insurance policy by id",
+            tags = {"id", "get"})
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        try {
+            return new ResponseEntity<>(insurancePolicyService.findById(id), HttpStatus.OK);
+        } catch (InsurancePolicyNotFoundException e) {
+            return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.NOT_FOUND);
+        } catch (InsurancePolicyException e) {
+            return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(
+            summary = "Find all",
+            description = "Returns the information of all insurance policies",
+            tags = {"all", "get"})
+    @GetMapping
+    public ResponseEntity<?> findAll() {
+        try {
+            return new ResponseEntity<>(insurancePolicyService.findAll(), HttpStatus.OK);
+        } catch (InsurancePolicyException e) {
+            return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(
+            summary = "Add a new insurance policy",
+            description = "Returns the information of the insurance policy added",
+            tags = {"add", "post"})
+    @PostMapping
+    public ResponseEntity<?> add(@RequestBody InsurancePolicyDto payload) {
+        try {
+            return new ResponseEntity<>(insurancePolicyService.add(payload), HttpStatus.CREATED);
+        } catch (InsurancePolicyException e) {
+            return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(
+            summary = "Update a insurance policy",
+            description = "Returns the information of the insurance policy updated",
+            tags = {"update", "put"})
+    @PutMapping
+    public ResponseEntity<?> update(@RequestBody InsurancePolicyDto payload) {
+        try {
+            return new ResponseEntity<>(insurancePolicyService.update(payload), HttpStatus.NO_CONTENT);
+        } catch (InsurancePolicyException e) {
+            return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(
+            summary = "Delete a insurance policy",
+            description = "Delete a insurance policy by id",
+            tags = {"id", "delete"})
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteById(@PathVariable Long id) {
+        try {
+            insurancePolicyService.deleteById(id);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (InsurancePolicyException e) {
+            return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/br/com/solutis/locadora/controller/rent/InsurancePolicyController.java
+++ b/src/main/java/br/com/solutis/locadora/controller/rent/InsurancePolicyController.java
@@ -22,8 +22,8 @@ public class InsurancePolicyController {
     private final InsurancePolicyService insurancePolicyService;
 
     @Operation(
-            summary = "Find by id",
-            description = "Returns the information of a insurance policy by id",
+            summary = "Listar por id",
+            description = "Retorna as informações do seguro por id",
             tags = {"id", "get"})
     @GetMapping("/{id}")
     public ResponseEntity<?> findById(@PathVariable Long id) {
@@ -37,8 +37,8 @@ public class InsurancePolicyController {
     }
 
     @Operation(
-            summary = "Find all",
-            description = "Returns the information of all insurance policies",
+            summary = "Listar todos",
+            description = "Retorna as informações de todos os seguros",
             tags = {"all", "get"})
     @GetMapping
     public ResponseEntity<?> findAll() {
@@ -50,8 +50,8 @@ public class InsurancePolicyController {
     }
 
     @Operation(
-            summary = "Add a new insurance policy",
-            description = "Returns the information of the insurance policy added",
+            summary = "Adicionar um novo seguro",
+            description = "Retorna as informações do seguro adicionado",
             tags = {"add", "post"})
     @PostMapping
     public ResponseEntity<?> add(@RequestBody InsurancePolicyDto payload) {
@@ -63,8 +63,8 @@ public class InsurancePolicyController {
     }
 
     @Operation(
-            summary = "Update a insurance policy",
-            description = "Returns the information of the insurance policy updated",
+            summary = "Atualiza um seguro",
+            description = "Retorna o codigo 204 (No Content)",
             tags = {"update", "put"})
     @PutMapping
     public ResponseEntity<?> update(@RequestBody InsurancePolicyDto payload) {
@@ -76,8 +76,8 @@ public class InsurancePolicyController {
     }
 
     @Operation(
-            summary = "Delete a insurance policy",
-            description = "Delete a insurance policy by id",
+            summary = "Apaga um seguro por id",
+            description = ""Retorna o codigo 204 (No Content)",
             tags = {"id", "delete"})
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteById(@PathVariable Long id) {

--- a/src/main/java/br/com/solutis/locadora/exception/rent/InsurancePolicyException.java
+++ b/src/main/java/br/com/solutis/locadora/exception/rent/InsurancePolicyException.java
@@ -1,0 +1,7 @@
+package br.com.solutis.locadora.exception.rent;
+
+public class InsurancePolicyException extends RuntimeException{
+    public InsurancePolicyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/br/com/solutis/locadora/exception/rent/InsurancePolicyNotFoundException.java
+++ b/src/main/java/br/com/solutis/locadora/exception/rent/InsurancePolicyNotFoundException.java
@@ -1,0 +1,7 @@
+package br.com.solutis.locadora.exception.rent;
+
+public class InsurancePolicyNotFoundException extends RuntimeException{
+    public InsurancePolicyNotFoundException(Long id) {
+        super("Insurance Policy with ID " + id + " not found.");
+    }
+}

--- a/src/main/java/br/com/solutis/locadora/response/ErrorResponse.java
+++ b/src/main/java/br/com/solutis/locadora/response/ErrorResponse.java
@@ -1,0 +1,17 @@
+package br.com.solutis.locadora.response;
+
+public class ErrorResponse {
+    private String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/br/com/solutis/locadora/service/rent/InsurancePolicyService.java
+++ b/src/main/java/br/com/solutis/locadora/service/rent/InsurancePolicyService.java
@@ -1,6 +1,7 @@
 package br.com.solutis.locadora.service.rent;
 
-import br.com.solutis.locadora.exception.BadRequestException;
+import br.com.solutis.locadora.exception.rent.InsurancePolicyException;
+import br.com.solutis.locadora.exception.rent.InsurancePolicyNotFoundException;
 import br.com.solutis.locadora.mapper.rent.InsurancePolicyMapper;
 import br.com.solutis.locadora.model.dto.rent.InsurancePolicyDto;
 import br.com.solutis.locadora.model.entity.rent.InsurancePolicy;
@@ -22,28 +23,48 @@ public class InsurancePolicyService implements CrudService<InsurancePolicyDto> {
 
     public InsurancePolicyDto findById(Long id) {
         return insurancePolicyRepository.findById(id).map(insurancePolicyMapper::modelToDTO)
-                .orElseThrow(() -> new BadRequestException("Insurance Policy Not found"));
+                .orElseThrow(() -> new InsurancePolicyNotFoundException(id));
     }
 
     public List<InsurancePolicyDto> findAll() {
-        return insurancePolicyMapper.listModelToListDto(insurancePolicyRepository.findAll());
+        try {
+            return insurancePolicyMapper.listModelToListDto(insurancePolicyRepository.findAll());
+        } catch (Exception e) {
+            throw new InsurancePolicyException("An error occurred while fetching insurance policies.", e);
+        }
     }
 
     public InsurancePolicyDto add(InsurancePolicyDto payload) {
-        InsurancePolicy insurancePolicy = insurancePolicyRepository
-                .save(insurancePolicyMapper.dtoToModel(payload));
+        try {
+            InsurancePolicy insurancePolicy = insurancePolicyRepository
+                    .save(insurancePolicyMapper.dtoToModel(payload));
 
-        return insurancePolicyMapper.modelToDTO(insurancePolicy);
+            return insurancePolicyMapper.modelToDTO(insurancePolicy);
+        } catch (Exception e) {
+            throw new InsurancePolicyException("An error occurred while adding insurance policy.", e);
+        }
     }
 
     public InsurancePolicyDto update(InsurancePolicyDto payload) {
-        return insurancePolicyRepository.findById(payload.getId()).map(insurancePolicy -> {
-            insurancePolicyRepository.save(insurancePolicyMapper.dtoToModel(payload));
+        findById(payload.getId());
+
+        try {
+            InsurancePolicy insurancePolicy = insurancePolicyRepository
+                    .save(insurancePolicyMapper.dtoToModel(payload));
+
             return insurancePolicyMapper.modelToDTO(insurancePolicy);
-        }).orElseThrow(() -> new BadRequestException("Insurance Policy Not found"));
+        } catch (Exception e) {
+            throw new InsurancePolicyException("An error occurred while updating insurance policy.", e);
+        }
     }
 
     public void deleteById(Long id) {
-        insurancePolicyRepository.deleteById(id);
+        findById(id);
+
+        try {
+            insurancePolicyRepository.deleteById(id);
+        } catch (Exception e) {
+            throw new InsurancePolicyException("An error occurred while deleting insurance policy.", e);
+        }
     }
 }


### PR DESCRIPTION
# Refatorando o Crud de seguro

## Alterações

- Criando erros personalizados para InsurancePolicy: **InsurancePolicyNotFoundException** e **InsurancePolicyException**.
- Criando uma resposta de erro.
- Implementando o add InsurancePolicy.
- Implementando o find by id InsurancePolicy.
- Implementando o find all InsurancePolicy.
- Implementando o update InsurancePolicy.
- Implementando o delete by id InsurancePolicy.
- Tratando os erros possiveis em InsurancePolicy.
- Colocando a documentação do swagger em português.